### PR TITLE
fix(config)!: `OCR_ENABLED` defaults to false

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -158,7 +158,7 @@ UNRTF_BINARY_PATH=
 ### OCR ###################################################
 
 # Expects true or false.
-# Defaults to true if unset
+# Defaults to false if unset
 OCR_ENABLED= 
 
 # The number of Tesseract workers to create.

--- a/.env.template
+++ b/.env.template
@@ -158,6 +158,7 @@ UNRTF_BINARY_PATH=
 ### OCR ###################################################
 
 # Expects true or false.
+# Please note that OCR functionality is CPU intensive, ensure that your hardware is suitable.
 # Defaults to false if unset
 OCR_ENABLED= 
 

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -51,7 +51,7 @@ describe("Configuration", () => {
 		const RATE_LIMIT_EXCLUDED_ARRAY = '["127.0.0.1"]';
 		const AUTH_BEARER_TOKEN_ARRAY =
 			'[{"service": "test", "value": "testtoken"}]';
-		const OCR_ENABLED = false;
+		const OCR_ENABLED = true;
 		const OCR_LANGUAGES = "chi_tra";
 		const OCR_WORKERS = 1;
 		const POPPLER_BINARY_PATH = "/usr/bin";
@@ -280,7 +280,7 @@ describe("Configuration", () => {
 
 		expect(config.tesseract).toEqual(
 			expect.objectContaining({
-				enabled: true,
+				enabled: false,
 				languages: "eng",
 				workers: expect.any(Number),
 			})

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -148,7 +148,7 @@ async function getConfig() {
 			.prop(
 				"OCR_ENABLED",
 				S.anyOf([
-					S.string().enum(["true", "false"]).default("true"),
+					S.string().enum(["true", "false"]).default("false"),
 					S.null(),
 				])
 			)
@@ -288,7 +288,7 @@ async function getConfig() {
 			tempDirectory,
 		},
 		tesseract: {
-			enabled: String(env.OCR_ENABLED).toLowerCase().trim() !== "false",
+			enabled: String(env.OCR_ENABLED).toLowerCase().trim() === "true",
 			languages: env.OCR_LANGUAGES || "eng",
 			// Use number of physical CPU cores available if ENV variable not specified
 			workers: env.OCR_WORKERS || physicalCpuCount,

--- a/src/routes/pdf/txt/schema.js
+++ b/src/routes/pdf/txt/schema.js
@@ -104,7 +104,7 @@ const pdfToTxtPostSchema = {
 		.prop(
 			"ocr",
 			S.boolean().description(
-				"Use Tesseract Optical Character Recognition (OCR) engine to attempt to read text from files that are composed of images or scans of documents. Please note that this is resource heavy and can be quite slow"
+				"Use Tesseract Optical Character Recognition (OCR) engine to attempt to read text from files that are composed of images or scans of documents. <strong>Please note that this is resource intensive and slow</strong>"
 			)
 		)
 		.prop(


### PR DESCRIPTION
BREAKING CHANGE: `OCR_ENABLED` environment variable now defaults to false.
Lower spec servers were struggling to run with the defaults, due to how CPU intensive Tesseract OCR workers are.