### PR TITLE
docs(readme): remove planned features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Docsmith is a RESTful API, built using Node.js and the [Fastify](https://www.fas
 -   RTF to TXT
 -   Scanned documents (as PDFs) to TXT using OCR
 
-Planned features include:
-
--   DOC to HTML
--   DOC to TXT
-
 ### Why Docsmith?
 
 Docsmith was created out of a need for an open-source document conversion service at [Yeovil District Hospital NHS Foundation Trust](https://yeovilhospital.co.uk/).


### PR DESCRIPTION
`.doc` files are notoriously difficult to parse due to them being based on the [Compound File Binary File Format](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/53989ce4-7b05-4f8d-829b-d08d6148375b), and tooling around it is sparse. The alternative is using LibreOffice or MS Office via the CLI, however that adds too much overhead.

closes #253
closes #254 