### PR TITLE
ci(cd): remove dev values from `package.json`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,17 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  cache: npm
+                  node-version: lts/*
+
+            - name: Remove dev values from package.json
+              run: |
+                  npm pkg delete commitlint devDependencies jest nodemonConfig scripts
+                  npm pkg set scripts.start="node ."
+
             - name: Create release asset
               run: >
                   zip -r ${{ github.event.repository.name }}-${{ needs.release.outputs.tag_name }}.zip


### PR DESCRIPTION
Should stop any malicious dev dependencies/scripts from being triggered in production if, when deploying, the user forgets the `--ignore-scripts --omit=dev` args.