### PR TITLE
chore!: drop support for node 14 and 16

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	env: {
-		es2020: true,
+		es2022: true,
 		node: true,
 	},
 	extends: [
@@ -14,7 +14,7 @@ module.exports = {
 		"prettier",
 	],
 	parserOptions: {
-		ecmaVersion: 2020,
+		ecmaVersion: 2022,
 	},
 	plugins: [
 		"import",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node-version: [14, 16, 18]
+                node-version: [18]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-bullseye-slim
+FROM node:18-bullseye-slim
 
 # Workdir
 WORKDIR /usr/app

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Docsmith enables a data processor to use a robust, GDPR-compliant, open-source d
 
 These are only required if running the API outside of Docker:
 
--   [Node.js](https://nodejs.org/en/) ^14.17.0 or >=16.0.0
+-   [Node.js](https://nodejs.org/en/) >=18.12.1
 -   Linux only: `poppler-data` >=0.4.9
 -   Linux only: `poppler-utils` >=20.12.0
 -   macOS only: `poppler` >=20.12.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
 				"prettier": "^2.7.1"
 			},
 			"engines": {
-				"node": "^14.17.0 || >=16.0.0"
+				"node": ">=18.12.1"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Frazer Smith <frazer.dev@outlook.com>",
 	"engines": {
-		"node": "^14.17.0 || >=16.0.0"
+		"node": ">=18.12.1"
 	},
 	"scripts": {
 		"benchmark:html": "autocannon -a 100 -m POST -i \"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf\" -H \"Content-Type:application/pdf\" \"http://0.0.0.0:3000/pdf/html?lastPageToConvert=1\"",


### PR DESCRIPTION
BREAKING CHANGE: minimum required version of node increased from 14.17.0 to 18.12.1

Node 14 and 16 becomes EOL in April and September 2023 respectively, which is the same time that [Yeovil District Hospital NHS Foundation Trust is due to merge with Somerset NHS Foundation Trust](https://yeovilhospital.co.uk/better-care-for-local-people-the-merger-of-yeovil-hospital-nhs-foundation-trust-with-somerset-nhs-foundation-trust/). Development will be focused on the merger at that point in time, so this PR preemptively drops support to reduce work load in the future.