### PR TITLE
test(plugins/tidy-css): html comments can end with exclamation marks

### DIFF
--- a/src/plugins/tidy-css/plugin.test.js
+++ b/src/plugins/tidy-css/plugin.test.js
@@ -44,7 +44,7 @@ describe("Tidy-CSS plugin", () => {
 			},
 		});
 
-		expect(/;}|<!--|-->/gm.exec(response.payload)).toBeNull();
+		expect(/;}|<!--|--!?>/gm.exec(response.payload)).toBeNull();
 		expect(typeof response.payload).toBe("string");
 		expect(isHtml(response.payload)).toBe(true);
 		expect(response.statusCode).toBe(200);
@@ -69,7 +69,7 @@ describe("Tidy-CSS plugin", () => {
 		});
 
 		expect(/font-family:Arial/gm.exec(response.payload)).not.toBeNull();
-		expect(/;}|<!--|-->/gm.exec(response.payload)).toBeNull();
+		expect(/;}|<!--|--!?>/gm.exec(response.payload)).toBeNull();
 		expect(typeof response.payload).toBe("string");
 		expect(isHtml(response.payload)).toBe(true);
 		expect(response.statusCode).toBe(200);
@@ -100,7 +100,7 @@ describe("Tidy-CSS plugin", () => {
 				response.payload
 			)
 		).not.toBeNull();
-		expect(/;}|<!--|-->/gm.exec(response.payload)).toBeNull();
+		expect(/;}|<!--|--!?>/gm.exec(response.payload)).toBeNull();
 		expect(typeof response.payload).toBe("string");
 		expect(isHtml(response.payload)).toBe(true);
 		expect(response.statusCode).toBe(200);
@@ -125,7 +125,7 @@ describe("Tidy-CSS plugin", () => {
 		});
 
 		expect(/background-color:#fff/gm.exec(response.payload)).not.toBeNull();
-		expect(/;}|<!--|-->/gm.exec(response.payload)).toBeNull();
+		expect(/;}|<!--|--!?>/gm.exec(response.payload)).toBeNull();
 		expect(typeof response.payload).toBe("string");
 		expect(isHtml(response.payload)).toBe(true);
 		expect(response.statusCode).toBe(200);
@@ -156,7 +156,7 @@ describe("Tidy-CSS plugin", () => {
 
 		expect(/font-family:Arial/gm.exec(response.payload)).not.toBeNull();
 		expect(/background-color:#fff/gm.exec(response.payload)).not.toBeNull();
-		expect(/;}|<!--|-->/gm.exec(response.payload)).toBeNull();
+		expect(/;}|<!--|--!?>/gm.exec(response.payload)).toBeNull();
 		expect(typeof response.payload).toBe("string");
 		expect(isHtml(response.payload)).toBe(true);
 		expect(response.statusCode).toBe(200);
@@ -180,7 +180,7 @@ describe("Tidy-CSS plugin", () => {
 			},
 		});
 
-		expect(/;}|<!--|-->/gm.exec(response.payload)).toBeNull();
+		expect(/;}|<!--|--!?>/gm.exec(response.payload)).toBeNull();
 		expect(typeof response.payload).toBe("string");
 		expect(isHtml(response.payload)).toBe(true);
 		expect(response.statusCode).toBe(200);


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/parsing.html#comment-end-bang-state

Closes #1275 