### PR TITLE
fix(routes/pdf): limit `outputEncoding` qs params to poppler charsets

### DIFF
--- a/src/plugins/pdf-to-html/index.js
+++ b/src/plugins/pdf-to-html/index.js
@@ -150,11 +150,7 @@ async function plugin(server, options) {
 		 * Remove excess title and meta elements left behind by Poppler;
 		 * Poppler appends `-html` to the file name
 		 */
-		const dom = new JSDOM(
-			await fs.readFile(`${tempFile}-html.html`, {
-				encoding: config.pdfToHtmlOptions.outputEncoding,
-			})
-		);
+		const dom = new JSDOM(await fs.readFile(`${tempFile}-html.html`));
 		const titles = dom.window.document.querySelectorAll("title");
 
 		// Overwrite title set by Poppler, which reveals directories

--- a/src/routes/pdf/html/schema.js
+++ b/src/routes/pdf/html/schema.js
@@ -98,6 +98,7 @@ const pdfToHtmlPostSchema = {
 				.description("Sets the encoding to use for text output")
 				// Encodings supported by Poppler
 				.enum([
+					"ASCII7",
 					"Big5",
 					"Big5ascii",
 					"EUC-CN",
@@ -111,12 +112,14 @@ const pdfToHtmlPostSchema = {
 					"ISO-8859-8",
 					"ISO-8859-9",
 					"KOI8-R",
+					"Latin1",
 					"Latin2",
 					"Shift-JIS",
 					"TIS-620",
 					"UTF-8",
 					"UTF-16",
 					"Windows-1255",
+					"ZapfDingbats",
 				])
 		)
 		.prop(

--- a/src/routes/pdf/html/schema.js
+++ b/src/routes/pdf/html/schema.js
@@ -96,7 +96,28 @@ const pdfToHtmlPostSchema = {
 			S.string()
 				.default("UTF-8")
 				.description("Sets the encoding to use for text output")
-				.pattern(/^[-\w]+$/m)
+				// Encodings supported by Poppler
+				.enum([
+					"Big5",
+					"Big5ascii",
+					"EUC-CN",
+					"EUC-JP",
+					"GBK",
+					"ISO-2022-CN",
+					"ISO-2022-JP",
+					"ISO-2022-KR",
+					"ISO-8859-6",
+					"ISO-8859-7",
+					"ISO-8859-8",
+					"ISO-8859-9",
+					"KOI8-R",
+					"Latin2",
+					"Shift-JIS",
+					"TIS-620",
+					"UTF-8",
+					"UTF-16",
+					"Windows-1255",
+				])
 		)
 		.prop(
 			"ownerPassword",

--- a/src/routes/pdf/txt/schema.js
+++ b/src/routes/pdf/txt/schema.js
@@ -109,6 +109,7 @@ const pdfToTxtPostSchema = {
 				.description("Sets the encoding to use for text output")
 				// Encodings supported by Poppler
 				.enum([
+					"ASCII7",
 					"Big5",
 					"Big5ascii",
 					"EUC-CN",
@@ -122,12 +123,14 @@ const pdfToTxtPostSchema = {
 					"ISO-8859-8",
 					"ISO-8859-9",
 					"KOI8-R",
+					"Latin1",
 					"Latin2",
 					"Shift-JIS",
 					"TIS-620",
 					"UTF-8",
 					"UTF-16",
 					"Windows-1255",
+					"ZapfDingbats",
 				])
 		)
 		.prop(

--- a/src/routes/pdf/txt/schema.js
+++ b/src/routes/pdf/txt/schema.js
@@ -107,7 +107,28 @@ const pdfToTxtPostSchema = {
 			S.string()
 				.default("UTF-8")
 				.description("Sets the encoding to use for text output")
-				.pattern(/^[-\w]+$/m)
+				// Encodings supported by Poppler
+				.enum([
+					"Big5",
+					"Big5ascii",
+					"EUC-CN",
+					"EUC-JP",
+					"GBK",
+					"ISO-2022-CN",
+					"ISO-2022-JP",
+					"ISO-2022-KR",
+					"ISO-8859-6",
+					"ISO-8859-7",
+					"ISO-8859-8",
+					"ISO-8859-9",
+					"KOI8-R",
+					"Latin2",
+					"Shift-JIS",
+					"TIS-620",
+					"UTF-8",
+					"UTF-16",
+					"Windows-1255",
+				])
 		)
 		.prop(
 			"ownerPassword",


### PR DESCRIPTION
Charsets like 'utf-32' are not supported and throws errors, so limit charsets to only Poppler supported ones.