### PR TITLE
fix(routes/pdf/txt): remove `listEncodingOptions` qs param

### DIFF
--- a/src/plugins/pdf-to-txt/index.js
+++ b/src/plugins/pdf-to-txt/index.js
@@ -60,7 +60,6 @@ async function plugin(server, options) {
 		"fixedWidthLayout",
 		"generateHtmlMetaFile",
 		"lastPageToConvert",
-		"listEncodingOptions",
 		"maintainLayout",
 		"noDiagonalText",
 		"noPageBreaks",

--- a/src/routes/pdf/txt/schema.js
+++ b/src/routes/pdf/txt/schema.js
@@ -83,10 +83,6 @@ const pdfToTxtPostSchema = {
 			S.number().description("Last page to convert")
 		)
 		.prop(
-			"listEncodingOptions",
-			S.boolean().description("List the available encodings")
-		)
-		.prop(
 			"maintainLayout",
 			S.boolean().description(
 				"Maintain (as best as possible) the original physical layout of the text. The default is to undo physical layout (columns, hyphenation, etc.) and output the text in reading order"


### PR DESCRIPTION
Barely worked and when it did it exposed underlying server details (the charsets).
Not a breaking change as it was broken to begin with!

https://github.com/Fdawgs/docsmith/pull/1353 will fill the space of listing supported encodings.