### PR TITLE
fix(config): missing `CORS_ORIGIN` env variable throws error

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -19,13 +19,9 @@ const { description, license, version } = require("../../package.json");
  * @returns {boolean|Array<string>|string} CORS parameter.
  */
 function parseCorsParameter(param) {
-	if (param.toLowerCase().trim() === "true") {
-		return true;
-	}
-	if (param.toLowerCase().trim() === "false") {
-		return false;
-	}
-	if (param.includes(",")) {
+	if (param?.toLowerCase().trim() === "true") return true;
+	if (param?.toLowerCase().trim() === "false") return false;
+	if (param?.includes(",")) {
 		return param
 			.trim()
 			.split(",")


### PR DESCRIPTION
Issue resolved with optional chaining on the if statements.