### PR TITLE
perf(plugins): replace `RegExp.test()` with `String.includes()`

### DIFF
--- a/src/plugins/pdf-to-html/index.js
+++ b/src/plugins/pdf-to-html/index.js
@@ -139,7 +139,7 @@ async function plugin(server, options) {
 			 * by client is malformed, thus client error code
 			 */
 			/* istanbul ignore else */
-			if (/Syntax Error:/.test(err)) {
+			if (err.message.includes("Syntax Error:")) {
 				throw server.httpErrors.badRequest();
 			}
 			/* istanbul ignore next: unable to test unknown errors */

--- a/src/plugins/pdf-to-txt/index.js
+++ b/src/plugins/pdf-to-txt/index.js
@@ -161,7 +161,7 @@ async function plugin(server, options) {
 				 * by client is malformed, thus client error code
 				 */
 				/* istanbul ignore else */
-				if (/Syntax Error:/.test(err)) {
+				if (err.message.includes("Syntax Error:")) {
 					throw server.httpErrors.badRequest();
 				}
 				/* istanbul ignore next: unable to test unknown errors */
@@ -203,7 +203,7 @@ async function plugin(server, options) {
 				 * by client is malformed, thus client error code
 				 */
 				/* istanbul ignore else */
-				if (/Syntax Error:/.test(err)) {
+				if (err.message.includes("Syntax Error:")) {
 					throw server.httpErrors.badRequest();
 				}
 				/* istanbul ignore next: unable to test unknown errors */

--- a/src/plugins/rtf-to-html/index.js
+++ b/src/plugins/rtf-to-html/index.js
@@ -169,7 +169,7 @@ async function plugin(server, options) {
 			 * by client is malformed, thus client error code
 			 */
 			/* istanbul ignore else */
-			if (/File is not the correct media type/.test(err)) {
+			if (err.message.includes("File is not the correct media type")) {
 				throw server.httpErrors.badRequest();
 			}
 			/* istanbul ignore next: unable to test unknown errors */


### PR DESCRIPTION
`.includes()` is way faster than `.test()`, see https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/RESULTS-v18.md#string-searching