### PR TITLE
refactor!: remove `outputEncoding` param for pdf routes

### DIFF
--- a/src/plugins/pdf-to-html/index.js
+++ b/src/plugins/pdf-to-html/index.js
@@ -51,7 +51,6 @@ async function plugin(server, options) {
 		"lastPageToConvert",
 		"noDrm",
 		"noMergeParagraph",
-		"outputEncoding",
 		"ownerPassword",
 		"userPassword",
 		"wordBreakThreshold",

--- a/src/plugins/pdf-to-txt/index.js
+++ b/src/plugins/pdf-to-txt/index.js
@@ -65,7 +65,6 @@ async function plugin(server, options) {
 		"maintainLayout",
 		"noDiagonalText",
 		"noPageBreaks",
-		"outputEncoding",
 		"ownerPassword",
 		"rawLayout",
 		"userPassword",

--- a/src/routes/pdf/html/schema.js
+++ b/src/routes/pdf/html/schema.js
@@ -92,37 +92,6 @@ const pdfToHtmlPostSchema = {
 			S.boolean().description("Do not merge paragraphs")
 		)
 		.prop(
-			"outputEncoding",
-			S.string()
-				.default("UTF-8")
-				.description("Sets the encoding to use for text output")
-				// Encodings supported by Poppler
-				.enum([
-					"ASCII7",
-					"Big5",
-					"Big5ascii",
-					"EUC-CN",
-					"EUC-JP",
-					"GBK",
-					"ISO-2022-CN",
-					"ISO-2022-JP",
-					"ISO-2022-KR",
-					"ISO-8859-6",
-					"ISO-8859-7",
-					"ISO-8859-8",
-					"ISO-8859-9",
-					"KOI8-R",
-					"Latin1",
-					"Latin2",
-					"Shift-JIS",
-					"TIS-620",
-					"UTF-8",
-					"UTF-16",
-					"Windows-1255",
-					"ZapfDingbats",
-				])
-		)
-		.prop(
 			"ownerPassword",
 			S.string()
 				.description("Owner password (for encrypted files)")

--- a/src/routes/pdf/txt/schema.js
+++ b/src/routes/pdf/txt/schema.js
@@ -99,37 +99,6 @@ const pdfToTxtPostSchema = {
 			)
 		)
 		.prop(
-			"outputEncoding",
-			S.string()
-				.default("UTF-8")
-				.description("Sets the encoding to use for text output")
-				// Encodings supported by Poppler
-				.enum([
-					"ASCII7",
-					"Big5",
-					"Big5ascii",
-					"EUC-CN",
-					"EUC-JP",
-					"GBK",
-					"ISO-2022-CN",
-					"ISO-2022-JP",
-					"ISO-2022-KR",
-					"ISO-8859-6",
-					"ISO-8859-7",
-					"ISO-8859-8",
-					"ISO-8859-9",
-					"KOI8-R",
-					"Latin1",
-					"Latin2",
-					"Shift-JIS",
-					"TIS-620",
-					"UTF-8",
-					"UTF-16",
-					"Windows-1255",
-					"ZapfDingbats",
-				])
-		)
-		.prop(
 			"ownerPassword",
 			S.string()
 				.description("Owner password (for encrypted files)")


### PR DESCRIPTION
BREAKING CHANGE: `outputEncoding` param removed from `pdf/html` and `pdf/txt` routes