### PR TITLE
test(server): disable plugin timeouts

### DIFF
--- a/src/server.test.js
+++ b/src/server.test.js
@@ -112,7 +112,7 @@ describe("Server deployment", () => {
 			});
 			config = await getConfig();
 
-			server = Fastify({ bodyLimit: 10485760, pluginTimeout: 30000 });
+			server = Fastify({ bodyLimit: 10485760, pluginTimeout: 0 });
 			await server.register(startServer, config).ready();
 		});
 
@@ -473,7 +473,7 @@ describe("Server deployment", () => {
 			});
 			config = await getConfig();
 
-			server = Fastify({ pluginTimeout: 30000 });
+			server = Fastify({ pluginTimeout: 0 });
 			await server.register(startServer, config).ready();
 		});
 
@@ -857,7 +857,7 @@ describe("Server deployment", () => {
 					Object.assign(process.env, envVariables);
 					config = await getConfig();
 
-					server = Fastify();
+					server = Fastify({ pluginTimeout: 0 });
 					await server.register(startServer, config).ready();
 				});
 
@@ -1003,7 +1003,7 @@ describe("Server deployment", () => {
 
 			// Turn off logging for test runs
 			config.fastifyInit.logger = undefined;
-			server = Fastify({ ...config.fastifyInit, pluginTimeout: 30000 });
+			server = Fastify({ ...config.fastifyInit, pluginTimeout: 0 });
 			await server.register(startServer, config).listen(config.fastify);
 		});
 
@@ -1089,7 +1089,7 @@ describe("Server deployment", () => {
 			});
 			config = await getConfig();
 
-			server = Fastify({ pluginTimeout: 30000 });
+			server = Fastify({ pluginTimeout: 0 });
 			await server.register(startServer, config);
 
 			server.get("/error", async () => {


### PR DESCRIPTION
Plugin load time impacted by test runner resource constraints