### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,7 +4,8 @@
 		// "checkJs": true,
 		// "strict": true,
 		"lib": ["ES2022"],
-		"moduleResolution": "nodenext",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"resolveJsonModule": true,
 		"target": "ES2022"
 	},

--- a/scripts/license-checker.js
+++ b/scripts/license-checker.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const { promisify } = require("util");
+const { promisify } = require("node:util");
 const { init } = require("license-checker");
 const copyLeftLicenses = require("spdx-copyleft");
 const path = require("upath");

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { rm } = require("fs/promises");
+const { rm } = require("node:fs/promises");
 const Fastify = require("fastify");
 const startServer = require("./server");
 const getConfig = require("./config");

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { unlink } = require("fs/promises");
+const { unlink } = require("node:fs/promises");
 const { glob } = require("glob");
 const path = require("upath");
 const getConfig = require(".");

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,7 @@
 
 require("dotenv").config();
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const envSchema = require("env-schema");
 const { getStream } = require("file-stream-rotator");
 const S = require("fluent-json-schema").default;

--- a/src/plugins/doc-to-txt/plugin.test.js
+++ b/src/plugins/doc-to-txt/plugin.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const sensible = require("@fastify/sensible");
 const plugin = require(".");

--- a/src/plugins/docx-to-html/index.js
+++ b/src/plugins/docx-to-html/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { randomUUID } = require("crypto");
+const { randomUUID } = require("node:crypto");
 const fixUtf8 = require("fix-utf8");
 const fp = require("fastify-plugin");
 const { JSDOM } = require("jsdom");

--- a/src/plugins/docx-to-html/plugin.test.js
+++ b/src/plugins/docx-to-html/plugin.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const { JSDOM } = require("jsdom");
 const sensible = require("@fastify/sensible");

--- a/src/plugins/embed-html-images/index.js
+++ b/src/plugins/embed-html-images/index.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const fp = require("fastify-plugin");
 const { JSDOM } = require("jsdom");
 const path = require("upath");

--- a/src/plugins/embed-html-images/plugin.test.js
+++ b/src/plugins/embed-html-images/plugin.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const { JSDOM } = require("jsdom");
 const plugin = require(".");

--- a/src/plugins/html-to-txt/plugin.test.js
+++ b/src/plugins/html-to-txt/plugin.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const sensible = require("@fastify/sensible");
 const plugin = require(".");

--- a/src/plugins/image-to-txt/plugin.test.js
+++ b/src/plugins/image-to-txt/plugin.test.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const plugin = require(".");
 const getConfig = require("../../config");

--- a/src/plugins/pdf-to-html/index.js
+++ b/src/plugins/pdf-to-html/index.js
@@ -2,8 +2,8 @@
 
 "use strict";
 
-const { randomUUID } = require("crypto");
-const { mkdir, readFile, unlink } = require("fs/promises");
+const { randomUUID } = require("node:crypto");
+const { mkdir, readFile, unlink } = require("node:fs/promises");
 const fixUtf8 = require("fix-utf8");
 const fp = require("fastify-plugin");
 const { glob } = require("glob");

--- a/src/plugins/pdf-to-html/plugin.test.js
+++ b/src/plugins/pdf-to-html/plugin.test.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const { readFile, readdir, rm } = require("fs/promises");
+const { readFile, readdir, rm } = require("node:fs/promises");
 const Fastify = require("fastify");
 const isHtml = require("is-html");
 const { JSDOM } = require("jsdom");

--- a/src/plugins/pdf-to-txt/index.js
+++ b/src/plugins/pdf-to-txt/index.js
@@ -2,8 +2,8 @@
 
 "use strict";
 
-const { randomUUID } = require("crypto");
-const { mkdir, unlink } = require("fs/promises");
+const { randomUUID } = require("node:crypto");
+const { mkdir, unlink } = require("node:fs/promises");
 const fixUtf8 = require("fix-utf8");
 const fp = require("fastify-plugin");
 const { glob } = require("glob");

--- a/src/plugins/pdf-to-txt/plugin.test.js
+++ b/src/plugins/pdf-to-txt/plugin.test.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const { readFile, readdir, rm } = require("fs/promises");
+const { readFile, readdir, rm } = require("node:fs/promises");
 const Fastify = require("fastify");
 const isHtml = require("is-html");
 const { JSDOM } = require("jsdom");

--- a/src/plugins/rtf-to-html/index.js
+++ b/src/plugins/rtf-to-html/index.js
@@ -2,8 +2,8 @@
 
 "use strict";
 
-const { randomUUID } = require("crypto");
-const { mkdir, rm, unlink, writeFile } = require("fs/promises");
+const { randomUUID } = require("node:crypto");
+const { mkdir, rm, unlink, writeFile } = require("node:fs/promises");
 const fixUtf8 = require("fix-utf8");
 const fp = require("fastify-plugin");
 const { glob } = require("glob");

--- a/src/plugins/rtf-to-html/plugin.test.js
+++ b/src/plugins/rtf-to-html/plugin.test.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const { readFile, readdir, rm } = require("fs/promises");
+const { readFile, readdir, rm } = require("node:fs/promises");
 const Fastify = require("fastify");
 const isHtml = require("is-html");
 const { JSDOM } = require("jsdom");

--- a/src/plugins/tidy-css/plugin.test.js
+++ b/src/plugins/tidy-css/plugin.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const { JSDOM } = require("jsdom");
 const plugin = require(".");

--- a/src/plugins/tidy-html/index.js
+++ b/src/plugins/tidy-html/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { promisify } = require("util");
+const { promisify } = require("node:util");
 const fp = require("fastify-plugin");
 const { JSDOM } = require("jsdom");
 // @ts-ignore

--- a/src/plugins/tidy-html/plugin.test.js
+++ b/src/plugins/tidy-html/plugin.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const { JSDOM } = require("jsdom");
 const sensible = require("@fastify/sensible");

--- a/src/routes/doc/txt/route.test.js
+++ b/src/routes/doc/txt/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const sensible = require("@fastify/sensible");

--- a/src/routes/docx/html/route.test.js
+++ b/src/routes/docx/html/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const sensible = require("@fastify/sensible");

--- a/src/routes/docx/txt/route.test.js
+++ b/src/routes/docx/txt/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const sensible = require("@fastify/sensible");

--- a/src/routes/html/txt/route.test.js
+++ b/src/routes/html/txt/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const sensible = require("@fastify/sensible");

--- a/src/routes/pdf/html/route.test.js
+++ b/src/routes/pdf/html/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const isHtml = require("is-html");

--- a/src/routes/pdf/txt/route.test.js
+++ b/src/routes/pdf/txt/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const isHtml = require("is-html");

--- a/src/routes/rtf/html/route.test.js
+++ b/src/routes/rtf/html/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const isHtml = require("is-html");

--- a/src/routes/rtf/txt/route.test.js
+++ b/src/routes/rtf/txt/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const accepts = require("@fastify/accepts");
 const Fastify = require("fastify");
 const isHtml = require("is-html");

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const Fastify = require("fastify");
 const isHtml = require("is-html");
 const { chromium, firefox } = require("playwright");

--- a/src/utils/core-count/index.js
+++ b/src/utils/core-count/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const { execSync } = require("child_process");
-const { cpus, EOL, platform } = require("os");
+const { execSync } = require("node:child_process");
+const { cpus, EOL, platform } = require("node:os");
 
 /**
  * @author Frazer Smith


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/37246/files#r588397158