### PR TITLE
fix(docker): `node` user permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts --omit=dev && \
     npm pkg delete commitlint devDependencies jest nodemonConfig scripts && \
     npm cache clean --force && \
-    chown node ./node_modules/htmltidy2/bin/linux64/tidy && \
     chmod 100 ./node_modules/htmltidy2/bin/linux64/tidy && \
     # Remove included Windows and macOS binaries
     rm -rf ./node_modules/node-poppler/src/lib/* && \
@@ -28,8 +27,8 @@ RUN npm ci --ignore-scripts --omit=dev && \
 
 # Copy source
 COPY . .
-## Allow for temp folder and contents to be removed on container exit
-RUN chown -R node ./dist/
+# Change ownership of all files and directories
+RUN chown -R node:node .
 
 # Node images provide 'node' unprivileged user to run apps and prevent
 # privilege escalation attacks


### PR DESCRIPTION
Fixes the following issue when attempting to deploy in certain instances:

![576e6c0d-a832-4d41-b749-3f3d3a729e5b](https://github.com/Fdawgs/docsmith/assets/43814140/29905956-b8be-4876-9ea1-184906990f4c)

This was due to the `node` user not having permissions to open `package.json`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
