### PR TITLE
refactor: move temp dirs out of `dist/` and `src/`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -119,8 +119,8 @@ out
 # Test files
 *.wmf
 *.emf
+temp*
 test_resources/
-dist/temp*/
 **/*.test.*
 
 # Development files

--- a/.env.template
+++ b/.env.template
@@ -25,7 +25,7 @@ CORS_ORIGIN=
 # Expects comma-delimited string i.e. "Content-Type, Authorization".
 # Defaults to reflecting the headers specified in the
 # request's "Access-Control-Request-Headers" header
-CORS_ALLOWED_HEADERS="Accept, Accept-Encoding, Accept-Language, Authorization, Content-Type, Origin, X-Forwarded-For, X-Requested-With"
+CORS_ALLOWED_HEADERS=
 
 # Set "Access-Control-Allow-Credentials" response header.
 # Expects true or to be unset

--- a/.gitignore
+++ b/.gitignore
@@ -143,9 +143,9 @@ yarn.lock
 # Test files
 *.wmf
 *.emf
+temp*
 test_resources/test-log*
 test_resources/.audit.json
-src/temp*/
 
 # Tesseract trained data
 ocr_lang_data/*.gz

--- a/.prettierignore
+++ b/.prettierignore
@@ -148,9 +148,9 @@ yarn.lock
 # Test files
 *.wmf
 *.emf
+temp*
 test_resources/test-log*
 test_resources/.audit.json
-src/temp*/
 
 # Tesseract trained data
 ocr_lang_data/*.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN npm ci --ignore-scripts --omit=dev && \
 COPY . .
 
 # Create temp folder for files to be stored whilst being converted
-RUN mkdir -p ./dist/temp/
+RUN mkdir -p ./temp/
 
 # ------------------
 # Final image

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Docsmith enables a data processor to use a comprehensive, GDPR-compliant, open-s
 
 These are only required if running the API outside of Docker:
 
--   [Node.js](https://nodejs.org/en/) >=18.12.1
+-   [Node.js](https://nodejs.org/en/) >=18.14.0
 -   Linux only: `poppler-data` >=0.4.9
 -   Linux only: `poppler-utils` >=20.12.0
 -   macOS only: `poppler` >=20.12.0

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,8 @@ async function main() {
 
 	const config = await getConfig();
 
+	console.log(config.tempDir);
+
 	const server = Fastify(config.fastifyInit);
 	await server.register(startServer, config).listen(config.fastify);
 

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -8,7 +8,7 @@ const { joinSafe } = require("upath");
 const getConfig = require(".");
 
 const originalEnv = { ...process.env, NODE_ENV: "development" };
-const tempDir = joinSafe(__dirname, "../temp");
+const tempDir = joinSafe(__dirname, "../../temp");
 
 describe("Configuration", () => {
 	afterEach(() => {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -42,7 +42,7 @@ function parseCorsParameter(param) {
  */
 async function getConfig() {
 	// Directory for temporarily storing files during conversion
-	const tempDir = joinSafe(__dirname, "../temp");
+	const tempDir = joinSafe(__dirname, "../../temp");
 
 	// Validate env variables
 	const env = envSchema({

--- a/src/plugins/pdf-to-html/plugin.test.js
+++ b/src/plugins/pdf-to-html/plugin.test.js
@@ -25,7 +25,7 @@ describe("PDF-to-HTML conversion plugin", () => {
 
 	beforeAll(async () => {
 		config = await getConfig();
-		config.poppler.tempDir = "./src/temp-test-pdf-to-html/";
+		config.poppler.tempDir = "./temp-test-pdf-to-html/";
 
 		server = Fastify();
 

--- a/src/plugins/pdf-to-txt/plugin.test.js
+++ b/src/plugins/pdf-to-txt/plugin.test.js
@@ -19,7 +19,7 @@ describe("PDF-to-TXT conversion plugin", () => {
 
 	beforeAll(async () => {
 		config = await getConfig();
-		config.poppler.tempDir = "./src/temp-test-pdf-to-txt/";
+		config.poppler.tempDir = "./temp-test-pdf-to-txt/";
 
 		server = Fastify({ pluginTimeout: 30000 });
 

--- a/src/plugins/rtf-to-html/plugin.test.js
+++ b/src/plugins/rtf-to-html/plugin.test.js
@@ -25,7 +25,7 @@ describe("RTF-to-HTML conversion plugin", () => {
 
 	beforeAll(async () => {
 		config = await getConfig();
-		config.unrtf.tempDir = "./src/temp-test-rtf-to-html/";
+		config.unrtf.tempDir = "./temp-test-rtf-to-html/";
 
 		server = Fastify({ bodyLimit: 10485760 });
 


### PR DESCRIPTION
Makes leftover temp dirs from failed tests more apparent.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
