### PR TITLE
build(docker): change ownership of workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ FROM node:20-bullseye-slim AS main
 # Workdir
 WORKDIR /usr/app
 
+# Change ownership of workdir to allow for temp dir to be deleted on exit
+RUN chown node:node /usr/app
+
 # Install OS dependencies
 # Curl needed for healthcheck command
 RUN apt-get -q update &&\


### PR DESCRIPTION
Stops the following error being thrown on shutdown:

```json
{
  "level": "error",
  "time": "2024-06-17T09:37:31.790Z",
  "pid": 1,
  "hostname": "ebd55f6520a2",
  "err": {
    "type": "Error",
    "message": "EACCES: permission denied, rmdir '/usr/app/temp'",
    "stack": "Error: EACCES: permission denied, rmdir '/usr/app/temp'",
    "errno": -13,
    "code": "EACCES",
    "syscall": "rmdir",
    "path": "/usr/app/temp"
  },
  "msg": "Error closing the application"
}

```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
