### PR TITLE
refactor(routes)!: rename camelCase query string params to snake_case

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,8 @@ updates:
           - dependency-name: esbuild-plugin-glob
           # Below are dependencies that have migrated to ESM
           # in their next major version so we can't use them
+          - dependency-name: camelcase
+            update-types: ["version-update:semver-major"]
           - dependency-name: file-type
             update-types: ["version-update:semver-major"]
           - dependency-name: is-html

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@fastify/static": "^8.0.3",
 				"@fastify/swagger": "^9.4.0",
 				"@fastify/under-pressure": "^9.0.1",
+				"camelcase": "^6.3.0",
 				"cfb": "^1.2.2",
 				"clean-css": "^5.3.3",
 				"cssesc": "^3.0.0",
@@ -1841,6 +1842,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
@@ -3851,13 +3862,15 @@
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true,
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/camelize": {
@@ -8918,19 +8931,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/jest-validate/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/jest-validate/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -10205,18 +10205,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/Fdawgs"
-			}
-		},
-		"node_modules/node-poppler/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/node-readfiles": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"@fastify/static": "^8.0.3",
 		"@fastify/swagger": "^9.4.0",
 		"@fastify/under-pressure": "^9.0.1",
+		"camelcase": "^6.3.0",
 		"cfb": "^1.2.2",
 		"clean-css": "^5.3.3",
 		"cssesc": "^3.0.0",

--- a/src/plugins/pdf-to-html/index.js
+++ b/src/plugins/pdf-to-html/index.js
@@ -4,6 +4,7 @@
 
 const { randomUUID } = require("node:crypto");
 const { mkdir, readFile, unlink } = require("node:fs/promises");
+const camelCase = require("camelcase");
 const { fixLatin1ToUtf8: fixUtf8 } = require("fix-latin1-to-utf8");
 const fp = require("fastify-plugin");
 const { glob } = require("glob");
@@ -93,17 +94,18 @@ async function plugin(server, options) {
 		/**
 		 * Create copy of query string params and prune that,
 		 * as some of the params may be used in other plugins.
+		 * @type {Record<string, string | number | boolean>}
 		 */
-		const query = { ...req.query };
-		Object.keys(query).forEach((value) => {
-			if (!pdfToHtmlAcceptedParams.has(value)) {
-				delete query[value];
-			} else {
+		const query = {};
+		Object.keys(req.query).forEach((key) => {
+			const camelCaseKey = camelCase(key);
+
+			if (pdfToHtmlAcceptedParams.has(camelCaseKey)) {
 				/**
-				 * Convert query string params to literal values to
+				 * Convert query string params to literal keys to
 				 * allow Poppler module to use them.
 				 */
-				query[value] = parseString(query[value]);
+				query[camelCaseKey] = parseString(req.query[key]);
 			}
 		});
 		Object.assign(config.pdfToHtmlOptions, query);

--- a/src/plugins/pdf-to-html/plugin.test.js
+++ b/src/plugins/pdf-to-html/plugin.test.js
@@ -73,8 +73,8 @@ describe("PDF-to-HTML conversion plugin", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				lastPageToConvert: "2",
-				ignoreImages: "false",
+				last_page_to_convert: "2",
+				ignore_images: "false",
 				...query,
 			},
 			headers: {
@@ -161,8 +161,8 @@ describe("PDF-to-HTML conversion plugin", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				lastPageToConvert: "1",
-				ignoreImages: "false",
+				last_page_to_convert: "1",
+				ignore_images: "false",
 			},
 			headers: {
 				"content-type": "application/pdf",

--- a/src/plugins/pdf-to-txt/index.js
+++ b/src/plugins/pdf-to-txt/index.js
@@ -4,6 +4,7 @@
 
 const { randomUUID } = require("node:crypto");
 const { mkdir, unlink } = require("node:fs/promises");
+const camelCase = require("camelcase");
 const { fixLatin1ToUtf8: fixUtf8 } = require("fix-latin1-to-utf8");
 const fp = require("fastify-plugin");
 const { glob } = require("glob");
@@ -111,10 +112,12 @@ async function plugin(server, options) {
 		 * Create copy of query string params and convert query string params to literal
 		 * values to allow Poppler module to use them, as some of the params may be used
 		 * in other plugins.
+		 * @type {Record<string, string | number | boolean>}
 		 */
-		const query = { ...req.query };
-		Object.keys(query).forEach((value) => {
-			query[value] = parseString(query[value]);
+		const query = {};
+		Object.keys(req.query).forEach((key) => {
+			const camelCaseKey = camelCase(key);
+			query[camelCaseKey] = parseString(req.query[key]);
 		});
 
 		const id = `${config.tempFilePrefix}_${randomUUID()}`;
@@ -126,9 +129,9 @@ async function plugin(server, options) {
 		 */
 		if (query.ocr === true && server.tesseract) {
 			// Prune params that pdfToCairo cannot accept
-			Object.keys(query).forEach((value) => {
-				if (!pdfToCairoAcceptedParams.has(value)) {
-					delete query[value];
+			Object.keys(query).forEach((key) => {
+				if (!pdfToCairoAcceptedParams.has(key)) {
+					delete query[key];
 				}
 			});
 
@@ -184,9 +187,9 @@ async function plugin(server, options) {
 			res.type("text/plain; charset=utf-8");
 		} else {
 			// Prune params that pdfToTxt cannot accept
-			Object.keys(query).forEach((value) => {
-				if (!pdfToTxtAcceptedParams.has(value)) {
-					delete query[value];
+			Object.keys(query).forEach((key) => {
+				if (!pdfToTxtAcceptedParams.has(key)) {
+					delete query[key];
 				}
 			});
 			Object.assign(config.pdfToTxtOptions, query);

--- a/src/plugins/pdf-to-txt/plugin.test.js
+++ b/src/plugins/pdf-to-txt/plugin.test.js
@@ -68,8 +68,8 @@ describe("PDF-to-TXT conversion plugin", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				firstPageToConvert: "2",
-				lastPageToConvert: "2",
+				first_page_to_convert: "2",
+				last_page_to_convert: "2",
 				...query,
 			},
 			headers: {
@@ -105,8 +105,8 @@ describe("PDF-to-TXT conversion plugin", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				firstPageToConvert: "1",
-				lastPageToConvert: "2",
+				first_page_to_convert: "1",
+				last_page_to_convert: "2",
 				...query,
 			},
 			headers: {
@@ -140,9 +140,9 @@ describe("PDF-to-TXT conversion plugin", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				firstPageToConvert: "2",
-				generateHtmlMetaFile: "true",
-				lastPageToConvert: "2",
+				first_page_to_convert: "2",
+				generate_html_meta_file: "true",
+				last_page_to_convert: "2",
 			},
 			headers: {
 				"content-type": "application/pdf",
@@ -188,7 +188,7 @@ describe("PDF-to-TXT conversion plugin", () => {
 			testName: "is not a valid PDF file for OCR",
 			body: Buffer.from("test"),
 			query: {
-				lastPageToConvert: "1",
+				last_page_to_convert: "1",
 				ocr: "true",
 			},
 		},
@@ -241,7 +241,7 @@ describe("PDF-to-TXT conversion plugin", () => {
 					"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 				),
 				query: {
-					lastPageToConvert: "1",
+					last_page_to_convert: "1",
 					...query,
 				},
 				headers: {

--- a/src/routes/docx/html/index.js
+++ b/src/routes/docx/html/index.js
@@ -79,7 +79,7 @@ async function route(server, options) {
 			res.type("text/html; charset=utf-8");
 			return server.tidyCss(tidiedHtml, {
 				fonts: req.query.fonts,
-				backgroundColor: req.query.backgroundColor,
+				backgroundColor: req.query.background_color,
 			});
 		},
 	});

--- a/src/routes/docx/html/index.js
+++ b/src/routes/docx/html/index.js
@@ -73,7 +73,7 @@ async function route(server, options) {
 			const html = await server.docxToHtml(req.body);
 			const tidiedHtml = await server.tidyHtml(html, {
 				language: req.query.language,
-				removeAlt: req.query.removeAlt,
+				removeAlt: req.query.remove_alt,
 			});
 
 			res.type("text/html; charset=utf-8");

--- a/src/routes/docx/html/route.test.js
+++ b/src/routes/docx/html/route.test.js
@@ -73,7 +73,7 @@ describe("DOCX-to-HTML route", () => {
 			url: "/",
 			body: await readFile(filePath),
 			query: {
-				removeAlt: "true",
+				remove_alt: "true",
 			},
 			headers: {
 				accept: "application/json, text/html",

--- a/src/routes/docx/html/schema.js
+++ b/src/routes/docx/html/schema.js
@@ -26,7 +26,7 @@ const docxToHtmlPostSchema = {
 	query: S.object()
 		.additionalProperties(false)
 		.prop(
-			"backgroundColor",
+			"background_color",
 			S.string()
 				.description(
 					"HTML document background color; set or replace the `background-color` property value of `div` CSS selectors"

--- a/src/routes/docx/html/schema.js
+++ b/src/routes/docx/html/schema.js
@@ -57,7 +57,7 @@ const docxToHtmlPostSchema = {
 				.default("en")
 		)
 		.prop(
-			"removeAlt",
+			"remove_alt",
 			S.boolean().description(
 				"Set the `alt` attribute in `<img>` tags to an empty string"
 			)

--- a/src/routes/html/txt/index.js
+++ b/src/routes/html/txt/index.js
@@ -68,7 +68,7 @@ async function route(server, options) {
 		},
 		handler: async (req, res) => {
 			const tidiedHtml = await server.tidyHtml(req.body, {
-				removeHidden: req.query.extractHidden !== true,
+				removeHidden: req.query.extract_hidden !== true,
 			});
 
 			res.type("text/plain; charset=utf-8");

--- a/src/routes/html/txt/route.test.js
+++ b/src/routes/html/txt/route.test.js
@@ -58,7 +58,7 @@ describe("HTML-to-TXT route", () => {
 				"content-type": "text/html",
 			},
 			query: {
-				extractHidden: "true",
+				extract_hidden: "true",
 			},
 		},
 		{
@@ -69,7 +69,7 @@ describe("HTML-to-TXT route", () => {
 				"content-type": "application/xhtml+xml",
 			},
 			query: {
-				extractHidden: "true",
+				extract_hidden: "true",
 			},
 		},
 	])("Returns $testName", async ({ filePath, headers, query }) => {

--- a/src/routes/html/txt/route.test.js
+++ b/src/routes/html/txt/route.test.js
@@ -132,9 +132,6 @@ describe("HTML-to-TXT route", () => {
 			method: "POST",
 			url: "/",
 			body: Buffer.from("test"),
-			query: {
-				lastPageToConvert: "1",
-			},
 			headers: {
 				accept: "application/json, text/plain",
 				"content-type": "text/html",

--- a/src/routes/html/txt/schema.js
+++ b/src/routes/html/txt/schema.js
@@ -21,7 +21,7 @@ const htmlToTxtPostSchema = {
 	query: S.object()
 		.additionalProperties(false)
 		.prop(
-			"extractHidden",
+			"extract_hidden",
 			S.boolean().description("Force hidden text extraction")
 		),
 	response: {

--- a/src/routes/pdf/html/index.js
+++ b/src/routes/pdf/html/index.js
@@ -76,7 +76,7 @@ async function route(server, options) {
 			);
 			const tidiedHtml = await server.tidyHtml(embeddedHtml, {
 				language: req.query.language,
-				removeAlt: req.query.removeAlt,
+				removeAlt: req.query.remove_alt,
 			});
 
 			return server.tidyCss(tidiedHtml, {

--- a/src/routes/pdf/html/index.js
+++ b/src/routes/pdf/html/index.js
@@ -81,7 +81,7 @@ async function route(server, options) {
 
 			return server.tidyCss(tidiedHtml, {
 				fonts: req.query.fonts,
-				backgroundColor: req.query.backgroundColor,
+				backgroundColor: req.query.background_color,
 			});
 		},
 	});

--- a/src/routes/pdf/html/route.test.js
+++ b/src/routes/pdf/html/route.test.js
@@ -16,7 +16,7 @@ const tidyHtml = require("../../../plugins/tidy-html");
 
 // Generates 64 different combinations
 const queryStrings = generateCombos([
-	{ backgroundColor: "white" },
+	{ background_color: "white" },
 	{ firstPageToConvert: "1" },
 	{ fonts: "Arial" },
 	{ ignoreImages: "true" },

--- a/src/routes/pdf/html/route.test.js
+++ b/src/routes/pdf/html/route.test.js
@@ -21,7 +21,7 @@ const queryStrings = generateCombos([
 	{ fonts: "Arial" },
 	{ ignoreImages: "true" },
 	{ noDrm: "true" },
-	{ removeAlt: "true" },
+	{ remove_alt: "true" },
 ]);
 
 describe("PDF-to-HTML route", () => {

--- a/src/routes/pdf/html/route.test.js
+++ b/src/routes/pdf/html/route.test.js
@@ -17,10 +17,10 @@ const tidyHtml = require("../../../plugins/tidy-html");
 // Generates 64 different combinations
 const queryStrings = generateCombos([
 	{ background_color: "white" },
-	{ firstPageToConvert: "1" },
+	{ first_page_to_convert: "1" },
 	{ fonts: "Arial" },
-	{ ignoreImages: "true" },
-	{ noDrm: "true" },
+	{ ignore_images: "true" },
+	{ no_drm: "true" },
 	{ remove_alt: "true" },
 ]);
 
@@ -57,7 +57,7 @@ describe("PDF-to-HTML route", () => {
 						body: await readFile(
 							"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 						),
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/html",
 							"content-type": "application/pdf",
@@ -85,7 +85,7 @@ describe("PDF-to-HTML route", () => {
 					.inject({
 						method: "POST",
 						url: "/",
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/html",
 							"content-type": "application/pdf",
@@ -114,7 +114,7 @@ describe("PDF-to-HTML route", () => {
 						method: "POST",
 						url: "/",
 						body: Buffer.from("test"),
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/html",
 							"content-type": "application/pdf",
@@ -145,7 +145,7 @@ describe("PDF-to-HTML route", () => {
 						body: await readFile(
 							"./test_resources/test_files/html_valid_empty.html"
 						),
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/html",
 							"content-type": "application/html",
@@ -173,7 +173,7 @@ describe("PDF-to-HTML route", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				lastPageToConvert: "1",
+				last_page_to_convert: "1",
 			},
 			headers: {
 				accept: "application/javascript",

--- a/src/routes/pdf/html/schema.js
+++ b/src/routes/pdf/html/schema.js
@@ -35,15 +35,15 @@ const pdfToHtmlPostSchema = {
 				])
 		)
 		.prop(
-			"exchangePdfLinks",
+			"exchange_pdf_links",
 			S.boolean().description("Exchange `.pdf` links with `.html`")
 		)
 		.prop(
-			"extractHidden",
+			"extract_hidden",
 			S.boolean().description("Force hidden text extraction")
 		)
 		.prop(
-			"firstPageToConvert",
+			"first_page_to_convert",
 			S.number()
 				.description("First page to convert")
 				.default(1)
@@ -59,14 +59,14 @@ const pdfToHtmlPostSchema = {
 				.examples(["Arial", "Arial, Sans Serif"])
 		)
 		.prop(
-			"fontFullName",
+			"font_full_name",
 			S.boolean().description(
 				"Output the font name without any substitutions"
 			)
 		)
-		.prop("ignoreImages", S.boolean().description("Ignore images"))
+		.prop("ignore_images", S.boolean().description("Ignore images"))
 		.prop(
-			"imageFormat",
+			"image_format",
 			S.string()
 				.description("Image file format for Splash output")
 				.enum(["JPG", "PNG"])
@@ -81,19 +81,19 @@ const pdfToHtmlPostSchema = {
 				.default("en")
 		)
 		.prop(
-			"lastPageToConvert",
+			"last_page_to_convert",
 			S.number().description("Last page to convert")
 		)
 		.prop(
-			"noDrm",
+			"no_drm",
 			S.boolean().description("Override document DRM settings")
 		)
 		.prop(
-			"noMergeParagraph",
+			"no_merge_paragraph",
 			S.boolean().description("Do not merge paragraphs")
 		)
 		.prop(
-			"ownerPassword",
+			"owner_password",
 			S.string()
 				.description("Owner password (for encrypted files)")
 				/**
@@ -109,7 +109,7 @@ const pdfToHtmlPostSchema = {
 			)
 		)
 		.prop(
-			"userPassword",
+			"user_password",
 			S.string()
 				.description("User password (for encrypted files)")
 				/**
@@ -119,7 +119,7 @@ const pdfToHtmlPostSchema = {
 				.maxLength(127)
 		)
 		.prop(
-			"wordBreakThreshold",
+			"word_break_threshold",
 			S.number()
 				.default(10)
 				.description(

--- a/src/routes/pdf/html/schema.js
+++ b/src/routes/pdf/html/schema.js
@@ -21,7 +21,7 @@ const pdfToHtmlPostSchema = {
 	query: S.object()
 		.additionalProperties(false)
 		.prop(
-			"backgroundColor",
+			"background_color",
 			S.string()
 				.description(
 					"HTML document background color; set or replace the `background-color` property value of `div` CSS selectors"

--- a/src/routes/pdf/html/schema.js
+++ b/src/routes/pdf/html/schema.js
@@ -103,7 +103,7 @@ const pdfToHtmlPostSchema = {
 				.maxLength(127)
 		)
 		.prop(
-			"removeAlt",
+			"remove_alt",
 			S.boolean().description(
 				"Set the `alt` attribute in `<img>` tags to an empty string"
 			)

--- a/src/routes/pdf/txt/index.js
+++ b/src/routes/pdf/txt/index.js
@@ -71,9 +71,9 @@ async function route(server, options) {
 			}
 		},
 		handler: async (req) =>
-			req.query.boundingBoxXhtml ||
-			req.query.boundingBoxXhtmlLayout ||
-			req.query.generateHtmlMetaFile
+			req.query.bounding_box_xhtml ||
+			req.query.bounding_box_xhtml_layout ||
+			req.query.generate_html_meta_file
 				? server.tidyHtml(req.conversionResults.body)
 				: req.conversionResults.body,
 	});

--- a/src/routes/pdf/txt/route.test.js
+++ b/src/routes/pdf/txt/route.test.js
@@ -15,11 +15,11 @@ const tidyHtml = require("../../../plugins/tidy-html");
 
 // Generates 32 different combinations
 const queryStrings = generateCombos([
-	{ firstPageToConvert: "1" },
-	{ eolConvention: "unix" },
-	{ maintainLayout: "true" },
-	{ noDiagonalText: "true" },
-	{ noPageBreaks: "true" },
+	{ first_page_to_convert: "1" },
+	{ eol_convention: "unix" },
+	{ maintain_layout: "true" },
+	{ no_diagonal_text: "true" },
+	{ no_page_breaks: "true" },
 ]);
 
 describe("PDF-to-TXT route", () => {
@@ -58,7 +58,7 @@ describe("PDF-to-TXT route", () => {
 						body: await readFile(
 							"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 						),
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/plain",
 							"content-type": "application/pdf",
@@ -86,7 +86,7 @@ describe("PDF-to-TXT route", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				lastPageToConvert: "1",
+				last_page_to_convert: "1",
 				ocr: "true",
 			},
 			headers: {
@@ -111,8 +111,8 @@ describe("PDF-to-TXT route", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				generateHtmlMetaFile: "true",
-				lastPageToConvert: "1",
+				generate_html_meta_file: "true",
+				last_page_to_convert: "1",
 			},
 			headers: {
 				accept: "application/json, text/html",
@@ -136,7 +136,7 @@ describe("PDF-to-TXT route", () => {
 					.inject({
 						method: "POST",
 						url: "/",
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/plain",
 							"content-type": "application/pdf",
@@ -165,7 +165,7 @@ describe("PDF-to-TXT route", () => {
 						method: "POST",
 						url: "/",
 						body: Buffer.from("test"),
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/plain",
 							"content-type": "application/pdf",
@@ -196,7 +196,7 @@ describe("PDF-to-TXT route", () => {
 						body: await readFile(
 							"./test_resources/test_files/html_valid_empty.html"
 						),
-						query: { ...queryString, lastPageToConvert: "1" },
+						query: { ...queryString, last_page_to_convert: "1" },
 						headers: {
 							accept: "application/json, text/plain",
 							"content-type": "application/html",
@@ -224,7 +224,7 @@ describe("PDF-to-TXT route", () => {
 				"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 			),
 			query: {
-				lastPageToConvert: "1",
+				last_page_to_convert: "1",
 			},
 			headers: {
 				accept: "application/javascript",

--- a/src/routes/pdf/txt/schema.js
+++ b/src/routes/pdf/txt/schema.js
@@ -20,43 +20,43 @@ const pdfToTxtPostSchema = {
 	produces: ["application/json", "application/xml"],
 	query: S.object()
 		.prop(
-			"boundingBoxXhtml",
+			"bounding_box_xhtml",
 			S.boolean().description(
 				"Generate an XHTML file containing bounding box information for each word in the file"
 			)
 		)
 		.prop(
-			"boundingBoxXhtmlLayout",
+			"bounding_box_xhtml_layout",
 			S.boolean().description(
 				"Generate an XHTML file containing bounding box information for each block, line, and word in the file"
 			)
 		)
 		.prop(
-			"cropHeight",
+			"crop_height",
 			S.number().description(
 				"Specifies the height of crop area in pixels (image output) or points (vector output)"
 			)
 		)
 		.prop(
-			"cropWidth",
+			"crop_width",
 			S.number().description(
 				"Specifies the width of crop area in pixels (image output) or points (vector output)"
 			)
 		)
 		.prop(
-			"cropXAxis",
+			"crop_x_axis",
 			S.number().description(
 				"Specifies the x-coordinate of the crop area top left corner in pixels (image output) or points (vector output)"
 			)
 		)
 		.prop(
-			"cropYAxis",
+			"crop_y_axis",
 			S.number().description(
 				"Specifies the y-coordinate of the crop area top left corner in pixels (image output) or points (vector output)"
 			)
 		)
 		.prop(
-			"eolConvention",
+			"eol_convention",
 			S.string()
 				.description(
 					"Sets the end-of-line convention to use for text output"
@@ -64,43 +64,43 @@ const pdfToTxtPostSchema = {
 				.enum(["dos", "mac", "unix"])
 		)
 		.prop(
-			"firstPageToConvert",
+			"first_page_to_convert",
 			S.number().default(1).description("First page to convert")
 		)
 		.prop(
-			"fixedWidthLayout",
+			"fixed_width_layout",
 			S.number().description(
 				"Assume fixed-pitch (or tabular) text, with the specified character width (in points). This forces physical layout mode"
 			)
 		)
 		.prop(
-			"generateHtmlMetaFile",
+			"generate_html_meta_file",
 			S.boolean().description(
 				"Generate simple HTML file, including the meta information. This simply wraps the text in `<pre>` and `</pre>` and prepends the meta headers"
 			)
 		)
 		.prop(
-			"lastPageToConvert",
+			"last_page_to_convert",
 			S.number().description("Last page to convert")
 		)
 		.prop(
-			"maintainLayout",
+			"maintain_layout",
 			S.boolean().description(
 				"Maintain (as best as possible) the original physical layout of the text. The default is to undo physical layout (columns, hyphenation, etc.) and output the text in reading order"
 			)
 		)
 		.prop(
-			"noDiagonalText",
+			"no_diagonal_text",
 			S.boolean().description("Discard diagonal text")
 		)
 		.prop(
-			"noPageBreaks",
+			"no_page_breaks",
 			S.boolean().description(
 				"Do not insert page breaks (form feed characters) between pages"
 			)
 		)
 		.prop(
-			"ownerPassword",
+			"owner_password",
 			S.string()
 				.description("Owner password (for encrypted files)")
 				/**
@@ -110,13 +110,13 @@ const pdfToTxtPostSchema = {
 				.maxLength(127)
 		)
 		.prop(
-			"rawLayout",
+			"raw_layout",
 			S.boolean().description(
 				"Keep the text in content stream order. This is a hack which often 'undoes' column formatting, etc. Use of raw mode is no longer recommended"
 			)
 		)
 		.prop(
-			"userPassword",
+			"user_password",
 			S.string()
 				.description("User password (for encrypted files)")
 				/**

--- a/src/routes/rtf/html/index.js
+++ b/src/routes/rtf/html/index.js
@@ -75,7 +75,7 @@ async function route(server, options) {
 				req.conversionResults.body,
 				{
 					language: req.query.language,
-					removeAlt: req.query.removeAlt,
+					removeAlt: req.query.remove_alt,
 				}
 			);
 

--- a/src/routes/rtf/html/index.js
+++ b/src/routes/rtf/html/index.js
@@ -81,7 +81,7 @@ async function route(server, options) {
 
 			return server.tidyCss(tidiedHtml, {
 				fonts: req.query.fonts,
-				backgroundColor: req.query.backgroundColor,
+				backgroundColor: req.query.background_color,
 			});
 		},
 	});

--- a/src/routes/rtf/html/route.test.js
+++ b/src/routes/rtf/html/route.test.js
@@ -15,7 +15,7 @@ const tidyHtml = require("../../../plugins/tidy-html");
 
 // Generates 12 different combinations
 const queryStrings = generateCombos([
-	{ backgroundColor: "white" },
+	{ background_color: "white" },
 	{ fonts: "Arial" },
 	{ fonts: "Arial, Sans Serif" },
 	{ language: "fr" },

--- a/src/routes/rtf/html/schema.js
+++ b/src/routes/rtf/html/schema.js
@@ -21,7 +21,7 @@ const rtfToHtmlPostSchema = {
 	query: S.object()
 		.additionalProperties(false)
 		.prop(
-			"backgroundColor",
+			"background_color",
 			S.string()
 				.description(
 					"HTML document background color; set or replace the `background-color` property value of `div` CSS selectors"

--- a/src/routes/rtf/html/schema.js
+++ b/src/routes/rtf/html/schema.js
@@ -52,7 +52,7 @@ const rtfToHtmlPostSchema = {
 				.default("en")
 		)
 		.prop(
-			"removeAlt",
+			"remove_alt",
 			S.boolean().description(
 				"Set the `alt` attribute in `<img>` tags to an empty string"
 			)

--- a/src/routes/rtf/txt/route.test.js
+++ b/src/routes/rtf/txt/route.test.js
@@ -79,9 +79,6 @@ describe("RTF-to-TXT route", () => {
 			method: "POST",
 			url: "/",
 			body: Buffer.from("test"),
-			query: {
-				lastPageToConvert: "1",
-			},
 			headers: {
 				accept: "application/json, text/plain",
 				"content-type": "application/rtf",

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -349,7 +349,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 					},
 					headers: {
 						accept: "application/json, text/html",
@@ -371,7 +371,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 					},
 					headers: {
 						accept: "application/javascript",
@@ -398,7 +398,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 					},
 					headers: {
 						accept: "application/json, text/plain",
@@ -567,7 +567,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 					},
 					headers: {
 						accept: "application/json, text/html",
@@ -590,7 +590,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 					},
 					headers: {
 						accept: "application/json, text/html",
@@ -611,7 +611,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 					},
 					headers: {
 						accept: "application/javascript",
@@ -639,7 +639,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 						ocr: "true",
 					},
 					headers: {
@@ -663,7 +663,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 						ocr: "true",
 					},
 					headers: {
@@ -685,7 +685,7 @@ describe("Server deployment", () => {
 						"./test_resources/test_files/pdf_1.3_NHS_Constitution.pdf"
 					),
 					query: {
-						lastPageToConvert: "1",
+						last_page_to_convert: "1",
 						ocr: "true",
 					},
 					headers: {


### PR DESCRIPTION
BREAKING CHANGE: all camelCase query string params renamed to snake_case, i.e. `backgroundColor` is now `background_color`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
