### PR TITLE
fix(plugins/rtf-to-html): flush file buffer to disk before reading file

### DIFF
--- a/src/plugins/rtf-to-html/index.js
+++ b/src/plugins/rtf-to-html/index.js
@@ -95,6 +95,7 @@ async function plugin(server, options) {
 		// 0600 permissions (read/write for owner only)
 		await writeFile(tempFile, req.body, {
 			encoding: "utf8",
+			flush: true,
 			mode: 0o600,
 		});
 


### PR DESCRIPTION
When data is written to a file, it may be temporarily stored in buffer memory to optimise performance. Because of this, there is a chance that Node will attempt to interact with a file before it has finished being written to disk, meaning that the RTF plugin may attempt to read partial files, posing a data integrity issue.

The `flush` param was added in Node 20.10, which ensures all data in the buffer is written to the disk immediately.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
