### PR TITLE
fix(server): disable auth for cors requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@fastify/accepts": "^5.0.2",
 				"@fastify/autoload": "^6.1.0",
-				"@fastify/bearer-auth": "^10.0.2",
+				"@fastify/bearer-auth": "^10.1.0",
 				"@fastify/compress": "^8.0.1",
 				"@fastify/cors": "^10.0.2",
 				"@fastify/helmet": "^13.0.1",
@@ -1659,9 +1659,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@fastify/bearer-auth": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@fastify/bearer-auth/-/bearer-auth-10.0.2.tgz",
-			"integrity": "sha512-kOxCzGpy7wv07+Xs3wCjEAfkMrdFEOqU07yRnknxQsVEn/IZF1Ow2Fv3+uSQ2Bj5k6yUR8Owrs7NS+W82R/joQ==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/bearer-auth/-/bearer-auth-10.1.0.tgz",
+			"integrity": "sha512-aeCOSjmo8ktWvdCMRljs6hdRcuC9+Q0z0hODmrql1RC2QiQW6WWT1Gl8fmH2daKwUDOUNuICiT8dcpk6rlnt+g==",
 			"funding": [
 				{
 					"type": "github",
@@ -1672,6 +1672,7 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"@fastify/error": "^4.0.0",
 				"fastify-plugin": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 	"dependencies": {
 		"@fastify/accepts": "^5.0.2",
 		"@fastify/autoload": "^6.1.0",
-		"@fastify/bearer-auth": "^10.0.2",
+		"@fastify/bearer-auth": "^10.1.0",
 		"@fastify/compress": "^8.0.1",
 		"@fastify/cors": "^10.0.2",
 		"@fastify/helmet": "^13.0.1",

--- a/src/server.js
+++ b/src/server.js
@@ -133,6 +133,8 @@ async function plugin(server, config) {
 		.register(async (securedContext) => {
 			if (config.bearerTokenAuthKeys) {
 				await securedContext.register(bearer, {
+					// Ensure auth is after CORS onRequest hook to avoid authenticating preflight requests
+					addHook: "preParsing",
 					keys: config.bearerTokenAuthKeys,
 					errorResponse: (err) => ({
 						statusCode: 401,


### PR DESCRIPTION
Stops pre-flight requests from getting caught.

OPTIONS routes don't need auth as they don't expose anything. They are rate-limited so protected against someone hammering them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
