### PR TITLE
perf: use `for` loop over `for...of` loop

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -413,8 +413,10 @@ async function getConfig() {
 	// Bearer token auth
 	if (env.AUTH_BEARER_TOKEN_ARRAY) {
 		const keys = new Set();
-		for (const element of secureParse(env.AUTH_BEARER_TOKEN_ARRAY)) {
-			keys.add(element.value);
+		const parsedArray = secureParse(env.AUTH_BEARER_TOKEN_ARRAY);
+		const parsedArraylength = parsedArray.length;
+		for (let i = 0; i < parsedArraylength; i += 1) {
+			keys.add(parsedArray[i].value);
 		}
 		config.bearerTokenAuthKeys = keys;
 

--- a/src/plugins/docx-to-html/plugin.test.js
+++ b/src/plugins/docx-to-html/plugin.test.js
@@ -88,8 +88,12 @@ describe("DOCX-to-HTML conversion plugin", () => {
 			)
 		).toMatchSnapshot();
 		// Expect all images to be embedded
-		for (const image of dom.window.document.querySelectorAll("img")) {
-			expect(image.src).toMatch(/^data:image\/(?:jpe?g|png);base64/iu);
+		const images = dom.window.document.querySelectorAll("img");
+		const imagesLength = images.length;
+		for (let i = 0; i < imagesLength; i += 1) {
+			expect(images[i].src).toMatch(
+				/^data:image\/(?:jpe?g|png);base64/iu
+			);
 		}
 		expect(response.statusCode).toBe(200);
 	});

--- a/src/plugins/embed-html-images/plugin.test.js
+++ b/src/plugins/embed-html-images/plugin.test.js
@@ -47,8 +47,12 @@ describe("Embed-HTML-Images plugin", () => {
 		const dom = new JSDOM(response.body);
 
 		expect(response.body).toMatchSnapshot();
-		for (const image of dom.window.document.querySelectorAll("img")) {
-			expect(image.src).toMatch(/^data:image\/(?:jpe?g|png);base64/iu);
+		const images = dom.window.document.querySelectorAll("img");
+		const imagesLength = images.length;
+		for (let i = 0; i < imagesLength; i += 1) {
+			expect(images[i].src).toMatch(
+				/^data:image\/(?:jpe?g|png);base64/iu
+			);
 		}
 		expect(response.statusCode).toBe(200);
 	});

--- a/src/plugins/pdf-to-html/index.js
+++ b/src/plugins/pdf-to-html/index.js
@@ -100,9 +100,11 @@ async function plugin(server, options) {
 		 * @type {Record<string, string | number | boolean>}
 		 */
 		const query = {};
-		for (const key of Object.keys(req.query)) {
+		const keys = Object.keys(req.query);
+		const keysLength = keys.length;
+		for (let i = 0; i < keysLength; i += 1) {
+			const key = keys[i];
 			const camelCaseKey = camelCase(key);
-
 			if (pdfToHtmlAcceptedParams.has(camelCaseKey)) {
 				/**
 				 * Convert query string params to literal keys to
@@ -154,11 +156,13 @@ async function plugin(server, options) {
 		 */
 		const dom = new JSDOM(await readFile(`${tempFile}-html.html`));
 		const titles = dom.window.document.querySelectorAll("title");
-		for (let i = 1; i < titles.length; i += 1) {
+		const titlesLength = titles.length;
+		for (let i = 1; i < titlesLength; i += 1) {
 			titles[i].remove();
 		}
 		const metas = dom.window.document.querySelectorAll("meta");
-		for (let i = 1; i < metas.length; i += 1) {
+		const metasLength = metas.length;
+		for (let i = 1; i < metasLength; i += 1) {
 			metas[i].remove();
 		}
 

--- a/src/plugins/pdf-to-txt/index.js
+++ b/src/plugins/pdf-to-txt/index.js
@@ -118,7 +118,10 @@ async function plugin(server, options) {
 		 * @type {Record<string, string | number | boolean>}
 		 */
 		const query = {};
-		for (const key of Object.keys(req.query)) {
+		const keys = Object.keys(req.query);
+		const keysLength = keys.length;
+		for (let i = 0; i < keysLength; i += 1) {
+			const key = keys[i];
 			const camelCaseKey = camelCase(key);
 			query[camelCaseKey] = parseString(req.query[key]);
 		}
@@ -132,7 +135,8 @@ async function plugin(server, options) {
 		 */
 		if (query.ocr === true && server.tesseract) {
 			// Prune params that pdfToCairo cannot accept
-			for (const key of Object.keys(query)) {
+			for (let i = 0; i < keysLength; i += 1) {
+				const key = keys[i];
 				if (!pdfToCairoAcceptedParams.has(key)) {
 					delete query[key];
 				}
@@ -192,7 +196,8 @@ async function plugin(server, options) {
 			res.type("text/plain; charset=utf-8");
 		} else {
 			// Prune params that pdfToTxt cannot accept
-			for (const key of Object.keys(query)) {
+			for (let i = 0; i < keysLength; i += 1) {
+				const key = keys[i];
 				if (!pdfToTxtAcceptedParams.has(key)) {
 					delete query[key];
 				}

--- a/src/plugins/tidy-css/index.js
+++ b/src/plugins/tidy-css/index.js
@@ -48,7 +48,9 @@ async function plugin(server) {
 
 		// Combine style elements into single element
 		const combinedStyle = dom.window.document.createElement("style");
-		for (const style of styles) {
+		const stylesLength = styles.length;
+		for (let i = 0; i < stylesLength; i += 1) {
+			const style = styles[i];
 			// @ts-ignore: textContent will never be null
 			combinedStyle.textContent += style.textContent;
 			style.remove();
@@ -56,7 +58,9 @@ async function plugin(server) {
 
 		// @ts-ignore: textContent will never be null
 		const styleObj = cssomParse(combinedStyle.textContent);
-		for (const rule of styleObj.cssRules) {
+		const cssRulesLength = styleObj.cssRules.length;
+		for (let i = 0; i < cssRulesLength; i += 1) {
+			const rule = styleObj.cssRules[i];
 			if (rule instanceof CSSStyleRule) {
 				// Replace default font
 				if (

--- a/src/plugins/tidy-html/index.js
+++ b/src/plugins/tidy-html/index.js
@@ -101,16 +101,16 @@ async function plugin(server) {
 
 			/** @type {string[]} */
 			const selectorsToRemove = [];
-
-			for (const style of styles) {
-				const styleElement = style;
+			const stylesLength = styles.length;
+			for (let i = 0; i < stylesLength; i += 1) {
+				const styleElement = styles[i];
 				// @ts-ignore: textContent will never be null
 				const styleObj = cssomParse(styleElement.textContent);
 				const cssRulesLength = styleObj.cssRules.length;
 
 				// Iterate over CSS rules in reverse to avoid index issues
-				for (let i = cssRulesLength - 1; i >= 0; i -= 1) {
-					const rule = styleObj.cssRules[i];
+				for (let j = cssRulesLength - 1; j >= 0; j -= 1) {
+					const rule = styleObj.cssRules[j];
 					if (rule instanceof CSSStyleRule) {
 						if (
 							rule.style.display === "none" ||
@@ -118,7 +118,7 @@ async function plugin(server) {
 						) {
 							selectorsToRemove.push(rule.selectorText);
 							// Remove rule from style tag
-							styleObj.deleteRule(i);
+							styleObj.deleteRule(j);
 						}
 					}
 				}
@@ -127,9 +127,14 @@ async function plugin(server) {
 			}
 
 			// Remove all elements that match the selectors
-			for (const selector of selectorsToRemove) {
-				for (const element of document.querySelectorAll(selector)) {
-					element.remove();
+			const selectorsLength = selectorsToRemove.length;
+			for (let i = 0; i < selectorsLength; i += 1) {
+				const elements = document.querySelectorAll(
+					selectorsToRemove[i]
+				);
+				const elementsLength = elements.length;
+				for (let j = 0; j < elementsLength; j += 1) {
+					elements[j].remove();
 				}
 			}
 

--- a/src/plugins/tidy-html/plugin.test.js
+++ b/src/plugins/tidy-html/plugin.test.js
@@ -70,8 +70,10 @@ describe("Tidy-HTML plugin", () => {
 		).toBe(options?.language || "en");
 
 		// Check alt attributes are removed if options.removeAlt is true
-		for (const image of dom.window.document.querySelectorAll("img")) {
-			expect(image.alt).toBe(
+		const images = dom.window.document.querySelectorAll("img");
+		const imagesLength = images.length;
+		for (let i = 0; i < imagesLength; i += 1) {
+			expect(images[i].alt).toBe(
 				options?.removeAlt ? "" : "background image"
 			);
 		}

--- a/test_resources/utils/bt-power-set.js
+++ b/test_resources/utils/bt-power-set.js
@@ -14,7 +14,8 @@ function btPowerSetRecursive(
 	currentSubSet = [],
 	startAt = 0
 ) {
-	for (let position = startAt; position < originalSet.length; position += 1) {
+	const originalSetLength = originalSet.length;
+	for (let position = startAt; position < originalSetLength; position += 1) {
 		currentSubSet.push(originalSet[position]);
 		allSubsets.push([...currentSubSet]);
 


### PR DESCRIPTION
`for...of` [has an iterator overhead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#description).

A traditional loop is faster because there are no intermediate objects created or function calls during iteration.
With the length being cached, there are no property lookups either.

See https://github.com/kibertoad/nodejs-benchmark-tournament for supporting benchmarking.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
