### PR TITLE
ci: use tags for immutable github actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,12 +41,12 @@ jobs:
             contents: write
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@v4
               with:
                   cache: npm
                   check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
@@ -52,12 +52,12 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@v4
               with:
                   cache: npm
                   check-latest: true
@@ -91,7 +91,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 0
                   persist-credentials: false
@@ -113,12 +113,12 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
             - name: Setup Node ${{ matrix.node-version }} on ${{ matrix.os }}
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@v4
               with:
                   cache: npm
                   check-latest: true
@@ -173,12 +173,12 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              uses: actions/setup-node@v4
               with:
                   cache: npm
                   check-latest: true
@@ -198,7 +198,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
@@ -217,7 +217,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,18 +37,18 @@ jobs:
             security-events: write
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 
             # Initialises the CodeQL tools for scanning
             - name: Initialise CodeQL
-              uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+              uses: github/codeql-action/init@v3
               with:
                   config-file: ./.github/codeql-config.yml
                   languages: ${{ matrix.languages }}
 
             - name: Perform CodeQL analysis
-              uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+              uses: github/codeql-action/analyze@v3
               with:
                   category: "/language:${{matrix.language}}"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -43,7 +43,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 

--- a/.github/workflows/optimise-images.yml
+++ b/.github/workflows/optimise-images.yml
@@ -37,7 +37,7 @@ jobs:
              github.event.pull_request.head.repo.full_name == github.repository)
         steps:
             - name: Check out repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              uses: actions/checkout@v4
               with:
                   persist-credentials: false
 


### PR DESCRIPTION
Most first party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes.