### PR TITLE
build(dependabot): group github-owned updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
           prefix: build
       cooldown:
           include:
-                - "*"
+              - "*"
           semver-major-days: 60
           semver-minor-days: 21
           semver-patch-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,16 +56,16 @@ updates:
           # in their next major version so they cannot be updated
           - dependency-name: camelcase
             update-types:
-              - "version-update:semver-major"
+                - "version-update:semver-major"
           - dependency-name: file-type
             update-types:
-              - "version-update:semver-major"
+                - "version-update:semver-major"
           - dependency-name: is-html
             update-types:
-              - "version-update:semver-major"
+                - "version-update:semver-major"
           - dependency-name: language-tags
             update-types:
-              - "version-update:semver-major"
+                - "version-update:semver-major"
       open-pull-requests-limit: 20
       schedule:
           interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
           include: scope
           prefix: ci
       directory: /
+      groups:
+          github-owned:
+              patterns:
+                  - "actions/*"
+                  - "github/*"
+                  - "octokit/*"
       open-pull-requests-limit: 20
       schedule:
           interval: monthly
@@ -14,7 +20,8 @@ updates:
           include: scope
           prefix: build
       cooldown:
-          include: ["*"]
+          include:
+                - "*"
           semver-major-days: 60
           semver-minor-days: 21
           semver-patch-days: 7
@@ -48,13 +55,17 @@ updates:
           # Below are dependencies that have migrated to ESM
           # in their next major version so they cannot be updated
           - dependency-name: camelcase
-            update-types: ["version-update:semver-major"]
+            update-types:
+              - "version-update:semver-major"
           - dependency-name: file-type
-            update-types: ["version-update:semver-major"]
+            update-types:
+              - "version-update:semver-major"
           - dependency-name: is-html
-            update-types: ["version-update:semver-major"]
+            update-types:
+              - "version-update:semver-major"
           - dependency-name: language-tags
-            update-types: ["version-update:semver-major"]
+            update-types:
+              - "version-update:semver-major"
       open-pull-requests-limit: 20
       schedule:
           interval: monthly


### PR DESCRIPTION
Reduces Dependabot PRs by grouping updates to GitHub-owned dependencies (actions/*, github/*, octokit/*) into a single PR.