### PR TITLE
ci: use full-length commit sha for github owned actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,12 +42,12 @@ jobs:
             contents: write
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   check-latest: true
                   node-version-file: .nvmrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
@@ -49,12 +49,12 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   cache: npm
                   check-latest: true
@@ -88,7 +88,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
                   persist-credentials: false
@@ -109,12 +109,12 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             - name: Setup Node ${{ matrix.node-version }} on ${{ matrix.os }}
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   cache: npm
                   check-latest: true
@@ -168,12 +168,12 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   cache: npm
                   check-latest: true
@@ -192,7 +192,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
@@ -210,7 +210,7 @@ jobs:
             contents: read
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,18 +39,18 @@ jobs:
             security-events: write
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 
             # Initialises the CodeQL tools for scanning
             - name: Initialise CodeQL
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
               with:
                   config-file: ./.github/codeql-config.yml
                   languages: ${{ matrix.language }}
 
             - name: Perform CodeQL analysis
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
               with:
                   category: "/language:${{ matrix.language }}"

--- a/.github/workflows/optimise-images.yml
+++ b/.github/workflows/optimise-images.yml
@@ -37,7 +37,7 @@ jobs:
              github.event.pull_request.head.repo.full_name == github.repository)
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
 


### PR DESCRIPTION
Use full-length commit sha for github owned actions just to be on safe side, especially after https://github.blog/security/investigating-unauthorized-access-to-githubs-internal-repositories/