### PR TITLE
chore(.vscode): remove redundant javascript default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,6 @@
 	"eslint.useFlatConfig": true,
 	"files.eol": "\n",
 	"gitlens.telemetry.enabled": false,
-	"[javascript]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	},
 	"js/ts.updateImportsOnFileMove.enabled": "always",
 	"npm.packageManager": "npm",
 	"prettier.prettierPath": "./node_modules/prettier/index.cjs",


### PR DESCRIPTION
Removed JavaScript default formatter setting. Not needed as it's not different from the standard default.