### PR TITLE
build(dependabot): remove scope from github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
     - package-ecosystem: github-actions
       commit-message:
-          include: scope
           prefix: ci
       directory: /
       groups:


### PR DESCRIPTION
CI is CI, no need for scope of 'deps' or 'deps-dev'