### PR TITLE
docs: fix broken links

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -55,7 +55,7 @@ DOCKER_APP_CPUS=
 # Defaults to 0 (use all available memory)
 DOCKER_APP_MEMORY=
 
-# Refer to https://docs.docker.com/compose/compose-file/compose-file-v3/#restart
+# Refer to https://docs.docker.com/reference/compose-file/services/#restart
 # for options.
 # Defaults to "unless-stopped"
 DOCKER_RESTART_POLICY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,15 +3,15 @@
 Contributions are welcome and any help that can be offered is greatly appreciated.
 Please take a moment to read the entire contributing guide.
 
-This repository uses the [Feature Branch Workflow](https://atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow),
+This repository uses the [Feature Branch Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow),
 meaning that development should take place in `feat/` branches, with the `main` branch kept in a stable state.
 When submitting pull requests, please make sure to fork from and submit back to `main`.
 
 Other processes and specifications that are in use in this repository are:
 
-- [Semantic versioning](https://semver.org/)
-- [Conventional commits](https://conventionalcommits.org/en/v1.0.0/) following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
-- [Prettier](https://prettier.io/) style guide
+- [Semantic versioning](https://semver.org)
+- [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+- [Prettier](https://prettier.io) style guide
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 # Docsmith
 
-[![GitHub release](https://img.shields.io/github/release/Fdawgs/docsmith.svg)](https://github.com/Fdawgs/docsmith/releases/latest/)
+[![GitHub release](https://img.shields.io/github/v/release/Fdawgs/docsmith)](https://github.com/Fdawgs/docsmith/releases/latest)
 [![CI](https://github.com/Fdawgs/docsmith/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Fdawgs/docsmith/actions/workflows/ci.yml)
 [![Coverage status](https://coveralls.io/repos/github/Fdawgs/docsmith/badge.svg?branch=main)](https://coveralls.io/github/Fdawgs/docsmith?branch=main)
-[![code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
+[![code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?style=flat)](https://github.com/prettier/prettier)
 [![OSSF Scorecard](https://api.scorecard.dev/projects/github.com/Fdawgs/docsmith/badge)](https://scorecard.dev/viewer/?uri=github.com/Fdawgs/docsmith)
 
 > RESTful API for converting clinical documents and files
 
 ## Overview
 
-Docsmith is a RESTful API, built using Node.js and the [Fastify](https://fastify.dev/) web framework, that can convert a range of files:
+Docsmith is a RESTful API, built using Node.js and the [Fastify](https://fastify.dev) web framework, that can convert a range of files:
 
 | Input | Output | Notes                                        |
 | ----- | ------ | -------------------------------------------- |
@@ -29,7 +29,7 @@ Docsmith is a RESTful API, built using Node.js and the [Fastify](https://fastify
 
 ### Why Docsmith?
 
-Docsmith was created in my spare time outside of work after identifying the need for an open-source document conversion service at Yeovil Hospital (ran by [Somerset NHS Foundation Trust](https://www.somersetft.nhs.uk/)).
+Docsmith was created in my spare time outside of work after identifying the need for an open-source document conversion service at Yeovil Hospital (ran by [Somerset NHS Foundation Trust](https://www.somersetft.nhs.uk)).
 
 Being open-source, with the ability to be self-hosted, enables a data processor (i.e. an NHS trust) to confirm that a service is not storing and logging files with confidential patient identifiable data (PID) in them, which is essential for preventing potential GDPR breaches. This is something that the majority of existing closed-source document conversion services cannot offer. Docsmith was built to remedy this.
 
@@ -41,7 +41,7 @@ Docsmith enables a data processor to use a comprehensive, GDPR-compliant, open-s
 
 These are only required if running the API outside of Docker:
 
-- [Node.js](https://nodejs.org/en/) >=20.0.0
+- [Node.js](https://nodejs.org/en) >=20.0.0
 - Linux only: `poppler-data` >=0.4.9
 - Linux only: `poppler-utils` >=20.12.0
 - macOS only: `poppler` >=20.12.0
@@ -83,17 +83,17 @@ The service should be up and running on the port set in the config. Output simil
 }
 ```
 
-To test it, use [Yaak](https://yaak.app/) and import the example requests from `./test/utils/yaak.docsmith.json`.
+To test it, use [Yaak](https://yaak.app) and import the example requests from `./test/utils/yaak.docsmith.json`.
 
 ### Deploying using Docker
 
-This requires [Docker](https://docker.com) installed.
+This requires [Docker](https://www.docker.com) installed.
 
 1. Run `docker compose up` (or `docker compose up -d` to run in the background)
 
 ### Deploying using PM2
 
-If this cannot be deployed into production using Docker, use a process manager such as [PM2](https://pm2.keymetrics.io/).
+If this cannot be deployed into production using Docker, use a process manager such as [PM2](https://pm2.keymetrics.io).
 
 1. Run `npm ci --ignore-scripts --omit=dev` to install dependencies
 2. Run `npm i -g pm2` to install pm2 globally

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -163,7 +163,7 @@ async function getConfig() {
 			// The maximum payload, in bytes, the server is allowed to accept
 			bodyLimit: env.REQ_BODY_MAX_BYTES || 10485760,
 			/**
-			 * @see {@link https://fastify.dev/docs/latest/Reference/Logging | Fastify logging}
+			 * @see {@link https://fastify.dev/docs/latest/Reference/Logging/ | Fastify logging}
 			 * @see {@link https://getpino.io/#/docs/api | Pino API}
 			 */
 			logger: {

--- a/src/plugins/pdf-to-html/index.js
+++ b/src/plugins/pdf-to-html/index.js
@@ -39,7 +39,7 @@ const POPPLER_PDF_TO_HTML_ACCEPTED_PARAMS = new Set([
  * @param {import("fastify").FastifyInstance} server - Fastify instance.
  * @param {object} options - Plugin config values.
  * @param {object} [options.pdfToHtmlOptions] - Refer to
- * https://github.com/Fdawgs/node-poppler/blob/main/API.md#Poppler+pdfToHtml
+ * https://github.com/Fdawgs/node-poppler/blob/main/src/options/pdftohtml.js
  * for options.
  * @param {string} options.tempDir - Directory for temporarily storing
  * files during conversion.

--- a/src/plugins/pdf-to-txt/index.js
+++ b/src/plugins/pdf-to-txt/index.js
@@ -52,7 +52,7 @@ const POPPLER_PDF_TO_TXT_ACCEPTED_PARAMS = new Set([
  * @param {import("fastify").FastifyInstance} server - Fastify instance.
  * @param {object} options - Plugin config values.
  * @param {object} [options.pdfToTxtOptions] - Refer to
- * https://github.com/Fdawgs/node-poppler/blob/main/API.md#Poppler+pdfToText
+ * https://github.com/Fdawgs/node-poppler/blob/main/src/options/pdftotext.js
  * for options.
  * @param {string} options.tempDir - Directory for temporarily storing
  * files during conversion. Required for OCR.

--- a/src/plugins/tidy-css/index.js
+++ b/src/plugins/tidy-css/index.js
@@ -69,7 +69,7 @@ async function plugin(server) {
 				/**
 				 * Font family names containing any non-alphabetical characters
 				 * other than hyphens should be quoted.
-				 * @see {@link https://w3.org/TR/css-fonts-4/#family-name-syntax | Syntax of <family-name>}
+				 * @see {@link https://www.w3.org/TR/css-fonts-4/#family-name-syntax | Syntax of <family-name>}
 				 */
 				if (rule.style["font-family"]) {
 					const fonts = rule.style["font-family"].split(",");

--- a/src/routes/admin/healthcheck/schema.js
+++ b/src/routes/admin/healthcheck/schema.js
@@ -8,7 +8,7 @@ const tags = ["System administration"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const healthcheckGetSchema = {
 	tags,

--- a/src/routes/doc/txt/schema.js
+++ b/src/routes/doc/txt/schema.js
@@ -8,7 +8,7 @@ const tags = ["DOC", "DOT"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const docToTxtPostSchema = {
 	tags,

--- a/src/routes/docs/openapi/schema.js
+++ b/src/routes/docs/openapi/schema.js
@@ -6,7 +6,7 @@ const S = require("fluent-json-schema").default;
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const docsOpenapiGetSchema = {
 	hide: true,

--- a/src/routes/docs/schema.js
+++ b/src/routes/docs/schema.js
@@ -6,7 +6,7 @@ const S = require("fluent-json-schema").default;
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const docsGetSchema = {
 	hide: true,

--- a/src/routes/docx/html/schema.js
+++ b/src/routes/docx/html/schema.js
@@ -8,7 +8,7 @@ const tags = ["DOCM", "DOCX", "DOTM", "DOTX"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const docxToHtmlPostSchema = {
 	tags,

--- a/src/routes/docx/txt/schema.js
+++ b/src/routes/docx/txt/schema.js
@@ -8,7 +8,7 @@ const tags = ["DOCM", "DOCX", "DOTM", "DOTX"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const docxToTxtPostSchema = {
 	tags,

--- a/src/routes/html/txt/schema.js
+++ b/src/routes/html/txt/schema.js
@@ -8,7 +8,7 @@ const tags = ["HTML"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const htmlToTxtPostSchema = {
 	tags,

--- a/src/routes/pdf/html/schema.js
+++ b/src/routes/pdf/html/schema.js
@@ -8,7 +8,7 @@ const tags = ["PDF"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const pdfToHtmlPostSchema = {
 	tags,

--- a/src/routes/pdf/txt/schema.js
+++ b/src/routes/pdf/txt/schema.js
@@ -8,7 +8,7 @@ const tags = ["PDF"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const pdfToTxtPostSchema = {
 	tags,

--- a/src/routes/rtf/html/schema.js
+++ b/src/routes/rtf/html/schema.js
@@ -8,7 +8,7 @@ const tags = ["RTF"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const rtfToHtmlPostSchema = {
 	tags,

--- a/src/routes/rtf/txt/schema.js
+++ b/src/routes/rtf/txt/schema.js
@@ -8,7 +8,7 @@ const tags = ["RTF"];
  * Fastify uses AJV for JSON Schema Validation.
  * Input validation protects against XSS, HPP, prototype pollution,
  * and most other injection attacks.
- * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization | Fastify Validation and Serialization}
+ * @see {@link https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/ | Fastify Validation and Serialization}
  */
 const rtfToTxtPostSchema = {
 	tags,

--- a/src/server.js
+++ b/src/server.js
@@ -56,7 +56,7 @@ async function plugin(server, config) {
 
 		/**
 		 * Use Helmet to set response security headers.
-		 * @see {@link https://helmetjs.github.io | Helmet}
+		 * @see {@link https://helmet.js.org | Helmet}
 		 */
 		.register(helmet, config.helmet)
 
@@ -128,7 +128,7 @@ async function plugin(server, config) {
 		/**
 		 * Encapsulate plugins and routes into a secured child context, so that admin and
 		 * docs routes do not inherit the bearer token auth plugin.
-		 * @see {@link https://fastify.dev/docs/latest/Reference/Encapsulation | Fastify Encapsulation}
+		 * @see {@link https://fastify.dev/docs/latest/Reference/Encapsulation/ | Fastify Encapsulation}
 		 */
 		.register(async (securedContext) => {
 			if (config.bearerTokenAuthKeys) {


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup.