### PR TITLE
build(dependabot): remove redundant includes cooldown array

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,6 @@ updates:
           include: scope
           prefix: build
       cooldown:
-          include:
-              - "*"
           semver-major-days: 60
           semver-minor-days: 21
           semver-patch-days: 7


### PR DESCRIPTION
All deps included by default, no need for array